### PR TITLE
Add DeepEval metrics, connector for them and tests

### DIFF
--- a/examples/metrics_usage_examples.py
+++ b/examples/metrics_usage_examples.py
@@ -1,0 +1,40 @@
+# To use metrics, simply import the desired one from ProtoLLM or directly from deepeval. In the second case, you
+# may also need to import a connector object for deepeval metrics to work. This can be done as follows:
+#
+# `from protollm.metrics.evaluation_metrics import model`
+#
+# Also make sure that you set the model URL and model_name in the same format as for a normal LLM connector
+# (URL;model_name).
+# Detailed documentation on metrics is available at the following URL:
+# https://docs.confident-ai.com/docs/metrics-introduction
+
+import logging
+
+from deepeval.test_case import LLMTestCase, ToolCall
+
+from protollm.metrics import answer_relevancy, tool_correctness
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+if __name__ == "__main__":
+    # Create test case for metric
+    test_case = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="We offer a 30-day full refund at no extra cost.",
+    )
+
+    answer_relevancy.measure(test_case) # Evaluate metric
+    logging.info(f"Answer relevancy score {answer_relevancy.score}")
+    logging.info(f"Answer relevancy reason: {answer_relevancy.reason}")
+    
+    test_case = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="We offer a 30-day full refund at no extra cost.",
+        # Replace this with the tools that was actually used by your LLM agent
+        tools_called=[ToolCall(name="WebSearch", input_parameters={}), ToolCall(name="ToolQuery", input_parameters={})],
+        expected_tools=[ToolCall(name="WebSearch", input_parameters={})],
+    )
+    
+    tool_correctness.measure(test_case)
+    logging.info(f"Tool correctness score {tool_correctness.score}")
+    logging.info(f"Tool correctness reason: {tool_correctness.reason}")

--- a/examples/metrics_usage_examples.py
+++ b/examples/metrics_usage_examples.py
@@ -1,32 +1,49 @@
-# To use metrics, simply import the desired one from ProtoLLM or directly from deepeval. In the second case, you
-# may also need to import a connector object for deepeval metrics to work. This can be done as follows:
+# You can use correctness_metric from ProtoLLM or import desired directly from deepeval.
+# The correctness metric is demonstrative, but has been shown to be good for determining the correctness of an answer.
+# You can define a new one, with a different criterion, if necessary.
 #
-# `from protollm.metrics.evaluation_metrics import model`
+# In the second case, you may also need to import a connector object for deepeval metrics to work. This can be done
+# as follows:
+#
+# `from protollm.metrics import model_for_metrics`
 #
 # Also make sure that you set the model URL and model_name in the same format as for a normal LLM connector
 # (URL;model_name).
+#
 # Detailed documentation on metrics is available at the following URL:
 # https://docs.confident-ai.com/docs/metrics-introduction
 
 import logging
 
+from deepeval.metrics import AnswerRelevancyMetric, ToolCorrectnessMetric
 from deepeval.test_case import LLMTestCase, ToolCall
 
-from protollm.metrics import answer_relevancy, tool_correctness
+from protollm.metrics import correctness_metric, model_for_metrics
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
+answer_relevancy = AnswerRelevancyMetric(model=model_for_metrics, async_mode=False)
+tool_correctness = ToolCorrectnessMetric()
+
 if __name__ == "__main__":
+    # ===================================metrics using LLM=============================================
     # Create test case for metric
     test_case = LLMTestCase(
         input="What if these shoes don't fit?",
         actual_output="We offer a 30-day full refund at no extra cost.",
+        expected_output="You are eligible for a 30 day full refund at no extra cost."
     )
 
     answer_relevancy.measure(test_case) # Evaluate metric
     logging.info(f"Answer relevancy score {answer_relevancy.score}")
     logging.info(f"Answer relevancy reason: {answer_relevancy.reason}")
     
+    correctness_metric.measure(test_case) # Evaluate metric
+    logging.info(f"Correctness score {correctness_metric.score}")
+    logging.info(f"Correctness reason: {correctness_metric.reason}")
+    
+    # ===================================metrics not using LLM=========================================
+    # Create test case for metric
     test_case = LLMTestCase(
         input="What if these shoes don't fit?",
         actual_output="We offer a 30-day full refund at no extra cost.",

--- a/protollm/metrics/__init__.py
+++ b/protollm/metrics/__init__.py
@@ -1,0 +1,8 @@
+from .evaluation_metrics import (answer_relevancy,
+                                 correctness_metric,
+                                 context_precision,
+                                 context_relevancy,
+                                 context_recall,
+                                 model_for_metrics,
+                                 task_completion,
+                                 tool_correctness)

--- a/protollm/metrics/__init__.py
+++ b/protollm/metrics/__init__.py
@@ -1,8 +1,1 @@
-from .evaluation_metrics import (answer_relevancy,
-                                 correctness_metric,
-                                 context_precision,
-                                 context_relevancy,
-                                 context_recall,
-                                 model_for_metrics,
-                                 task_completion,
-                                 tool_correctness)
+from .evaluation_metrics import correctness_metric, model_for_metrics

--- a/protollm/metrics/deepeval_connector.py
+++ b/protollm/metrics/deepeval_connector.py
@@ -1,0 +1,90 @@
+import os
+from dataclasses import dataclass
+from typing import Dict
+
+from dataclasses_json import dataclass_json
+from deepeval.models.base_model import DeepEvalBaseLLM
+from langchain_core.language_models.chat_models import BaseChatModel
+from pydantic import BaseModel
+from openai._types import NOT_GIVEN
+
+from protollm.connectors import create_llm_connector
+
+
+@dataclass_json
+@dataclass
+class Message:
+    """Template for message in following format {"role", "content"}."""
+
+    role: str
+    content: str
+
+    def to_dict(self) -> Dict:
+        return {"role": self.role, "content": self.content}
+
+
+class DeepEvalConnector(DeepEvalBaseLLM):
+    """Implementation of Evaluation agent based on large language model for Assistant's answers evaluation.
+
+    Uses the LangChain's ChatModel to make requests to a compatible API. Must inherit from the base class and
+    implement a set of methods.
+    The vsegpt.ru service is used by default, so in the configuration file it is necessary to specify the API key of
+    this service and the model name, as in the general case.
+    """
+
+    def __init__(self, sys_prompt: str = "", *args, **kwargs):
+        """Initialize instance with evaluation LLM.
+
+        Args:
+            model: Evaluation model's name
+            sys_prompt: predefined rules for model
+            base_url: URL where models are available
+        """
+        super().__init__(*args, **kwargs)
+        self._sys_prompt = sys_prompt
+        self.model = self.load_model()
+
+    @staticmethod
+    def load_model() -> BaseChatModel:
+        """Returns LangChain's ChatModel for requests"""
+        return create_llm_connector(os.getenv("LLM_URL"))
+
+    def generate(
+            self,
+            prompt: str,
+            *args,
+            **kwargs,
+    ) -> str | BaseModel:
+        """Get a response form LLM to given question.
+
+        Args:
+            prompt (str): Query, the model must answer.
+
+        Returns:
+            str: Model's response.
+        """
+        messages = [
+            {"role": "system", "content": self._sys_prompt},
+            {"role": "user", "content": prompt},
+        ]
+        response_format = kwargs.get("schema", NOT_GIVEN)
+        if response_format == NOT_GIVEN:
+            return self.model.invoke(messages).content
+        else:
+            struct_llm = self.model.with_structured_output(schema=response_format, method="json_mode")
+            return struct_llm.invoke(messages)
+
+    async def a_generate(
+            self,
+            prompt: str,
+            *args,
+            **kwargs,
+    ) -> str:
+        """Same as synchronous generate method just because it must be implemented"""
+        return self.generate(
+            prompt, *args, **kwargs
+        )
+
+    def get_model_name(self, *args, **kwargs) -> str:
+        """Returns a description of what the class is about"""
+        return "Implementation of custom LLM connector using OpenAI compatible API for evaluation."

--- a/protollm/metrics/deepeval_connector.py
+++ b/protollm/metrics/deepeval_connector.py
@@ -1,26 +1,11 @@
 import os
-from dataclasses import dataclass
-from typing import Dict
 
-from dataclasses_json import dataclass_json
 from deepeval.models.base_model import DeepEvalBaseLLM
 from langchain_core.language_models.chat_models import BaseChatModel
 from pydantic import BaseModel
 from openai._types import NOT_GIVEN
 
-from protollm.connectors import create_llm_connector
-
-
-@dataclass_json
-@dataclass
-class Message:
-    """Template for message in following format {"role", "content"}."""
-
-    role: str
-    content: str
-
-    def to_dict(self) -> Dict:
-        return {"role": self.role, "content": self.content}
+from ..connectors import create_llm_connector
 
 
 class DeepEvalConnector(DeepEvalBaseLLM):
@@ -36,9 +21,7 @@ class DeepEvalConnector(DeepEvalBaseLLM):
         """Initialize instance with evaluation LLM.
 
         Args:
-            model: Evaluation model's name
             sys_prompt: predefined rules for model
-            base_url: URL where models are available
         """
         super().__init__(*args, **kwargs)
         self._sys_prompt = sys_prompt
@@ -47,7 +30,7 @@ class DeepEvalConnector(DeepEvalBaseLLM):
     @staticmethod
     def load_model() -> BaseChatModel:
         """Returns LangChain's ChatModel for requests"""
-        return create_llm_connector(os.getenv("LLM_URL"))
+        return create_llm_connector(os.getenv("DEEPEVAL_LLM_URL", "test_model"))
 
     def generate(
             self,
@@ -55,7 +38,7 @@ class DeepEvalConnector(DeepEvalBaseLLM):
             *args,
             **kwargs,
     ) -> str | BaseModel:
-        """Get a response form LLM to given question.
+        """Get a response from LLM to given question.
 
         Args:
             prompt (str): Query, the model must answer.

--- a/protollm/metrics/evaluation_metrics.py
+++ b/protollm/metrics/evaluation_metrics.py
@@ -1,25 +1,14 @@
-from deepeval.metrics import (GEval,
-                              AnswerRelevancyMetric,
-                              FaithfulnessMetric,
-                              ContextualPrecisionMetric,
-                              ContextualRecallMetric,
-                              ContextualRelevancyMetric,
-                              TaskCompletionMetric,
-                              ToolCorrectnessMetric)
+from deepeval.metrics import GEval
 from deepeval.test_case import LLMTestCaseParams
 
-from protollm.metrics.deepeval_connector import DeepEvalConnector
+from .deepeval_connector import DeepEvalConnector
 
 model_for_metrics = DeepEvalConnector()
-metrics_init_params = {
-    "model": model_for_metrics,
-    "async_mode": False,
-}
 
-# Use LLMs
+# Custom metric for evaluating the correctness of an answer
 correctness_metric = GEval(
     name="Correctness",
-    criteria=( # Сan be overridden for a specific task
+    criteria=(
         "1. Correctness and Relevance:"
         "- Compare the actual response against the expected response. Determine the"
         " extent to which the actual response captures the key elements and concepts of"
@@ -45,14 +34,6 @@ correctness_metric = GEval(
         LLMTestCaseParams.ACTUAL_OUTPUT,
         LLMTestCaseParams.EXPECTED_OUTPUT,
     ],
-    **metrics_init_params,
+    model=model_for_metrics,
+    async_mode=False
 )
-answer_relevancy = AnswerRelevancyMetric(**metrics_init_params)
-faithfulness = FaithfulnessMetric(**metrics_init_params)
-context_precision = ContextualPrecisionMetric(**metrics_init_params)
-context_recall = ContextualRecallMetric(**metrics_init_params)
-context_relevancy = ContextualRelevancyMetric(**metrics_init_params)
-task_completion = TaskCompletionMetric(**metrics_init_params)
-
-# Don't use LLMs
-tool_correctness = ToolCorrectnessMetric()

--- a/protollm/metrics/evaluation_metrics.py
+++ b/protollm/metrics/evaluation_metrics.py
@@ -1,0 +1,58 @@
+from deepeval.metrics import (GEval,
+                              AnswerRelevancyMetric,
+                              FaithfulnessMetric,
+                              ContextualPrecisionMetric,
+                              ContextualRecallMetric,
+                              ContextualRelevancyMetric,
+                              TaskCompletionMetric,
+                              ToolCorrectnessMetric)
+from deepeval.test_case import LLMTestCaseParams
+
+from protollm.metrics.deepeval_connector import DeepEvalConnector
+
+model_for_metrics = DeepEvalConnector()
+metrics_init_params = {
+    "model": model_for_metrics,
+    "async_mode": False,
+}
+
+# Use LLMs
+correctness_metric = GEval(
+    name="Correctness",
+    criteria=( # Сan be overridden for a specific task
+        "1. Correctness and Relevance:"
+        "- Compare the actual response against the expected response. Determine the"
+        " extent to which the actual response captures the key elements and concepts of"
+        " the expected response."
+        "- Assign higher scores to actual responses that accurately reflect the core"
+        " information of the expected response, even if only partial."
+        "2. Numerical Accuracy and Interpretation:"
+        "- Pay particular attention to any numerical values present in the expected"
+        " response. Verify that these values are correctly included in the actual"
+        " response and accurately interpreted within the context."
+        "- Ensure that units of measurement, scales, and numerical relationships are"
+        " preserved and correctly conveyed."
+        "3. Allowance for Partial Information:"
+        "- Do not heavily penalize the actual response for incompleteness if it covers"
+        " significant aspects of the expected response. Prioritize the correctness of"
+        " provided information over total completeness."
+        "4. Handling of Extraneous Information:"
+        "- While additional information not present in the expected response should not"
+        " necessarily reduce score, ensure that such additions do not introduce"
+        " inaccuracies or deviate from the context of the expected response."
+    ),
+    evaluation_params=[
+        LLMTestCaseParams.ACTUAL_OUTPUT,
+        LLMTestCaseParams.EXPECTED_OUTPUT,
+    ],
+    **metrics_init_params,
+)
+answer_relevancy = AnswerRelevancyMetric(**metrics_init_params)
+faithfulness = FaithfulnessMetric(**metrics_init_params)
+context_precision = ContextualPrecisionMetric(**metrics_init_params)
+context_recall = ContextualRecallMetric(**metrics_init_params)
+context_relevancy = ContextualRelevancyMetric(**metrics_init_params)
+task_completion = TaskCompletionMetric(**metrics_init_params)
+
+# Don't use LLMs
+tool_correctness = ToolCorrectnessMetric()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ openai = "^1.42.0"
 tornado = "^6.4.1"
 langchain-openai = "0.3.3"
 langchain-gigachat = "0.3.3"
+deepeval= "2.3.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+deepeval==2.3.3
+
 # LangChain
 
 langchain>=0.3.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,267 @@
+from typing import Optional
+from unittest.mock import patch
+
+from deepeval.metrics.answer_relevancy.schema import AnswerRelevancyVerdict
+from deepeval.metrics.contextual_precision.schema import ContextualPrecisionVerdict
+from deepeval.metrics.contextual_recall.schema import ContextualRecallVerdict
+from deepeval.metrics.contextual_relevancy.schema import ContextualRelevancyVerdicts
+from deepeval.metrics.faithfulness.schema import FaithfulnessVerdict
+from deepeval.test_case import LLMTestCase, ToolCall
+from langchain_core.messages import AIMessage
+from pydantic import BaseModel, Field
+
+from protollm.metrics.deepeval_connector import DeepEvalConnector
+from protollm.metrics.evaluation_metrics import (answer_relevancy,
+                                                 context_precision,
+                                                 context_recall,
+                                                 context_relevancy,
+                                                 correctness_metric,
+                                                 faithfulness,
+                                                 task_completion,
+                                                 tool_correctness)
+
+
+class Joke(BaseModel):
+    """Joke to tell user."""
+    setup: str = Field(description="The setup of the joke")
+    punchline: str = Field(description="The punchline to the joke")
+    rating: Optional[int] = Field(
+        default=None, description="How funny the joke is, from 1 to 10"
+    )
+
+
+def test_metric_connector():
+    model = DeepEvalConnector()
+    mock_response = AIMessage(content="Hello, world!")
+    with patch.object(model, 'generate', return_value=mock_response):
+        result = model.generate("Hello")
+        assert result.content == "Hello, world!"
+
+
+def test_metric_connector_with_schema():
+    model = DeepEvalConnector()
+    mock_response = Joke.model_validate_json('{"setup": "test", "punchline": "test", "score": "7"}')
+    with patch.object(model, 'generate', return_value=mock_response):
+        response = model.generate(prompt="Tell me a joke", schema=Joke)
+        assert issubclass(type(response), BaseModel)
+
+
+def test_answer_relevancy_metric():
+    test_case = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="We offer a 30-day full refund at no extra cost.",
+    )
+    
+    with (
+        patch.object(
+            answer_relevancy, "_generate_statements", return_value=["first claim", "second claim"]
+        ) as mocked_statements,
+        patch.object(
+            answer_relevancy,
+            "_generate_verdicts",
+            return_value=[AnswerRelevancyVerdict(**{"verdict": "yes"}), AnswerRelevancyVerdict(**{"verdict": "no"})]
+        ) as mocked_verdicts,
+        patch.object(
+            answer_relevancy, "_generate_reason", return_value="all good"
+        ) as mocked_reason
+    ):
+        answer_relevancy.measure(test_case)
+        mocked_statements.assert_called_with(test_case.actual_output)
+        mocked_verdicts.assert_called_with(test_case.input)
+        mocked_reason.assert_called_with(test_case.input)
+        assert isinstance(answer_relevancy.score, float)
+        assert isinstance(answer_relevancy.reason, str)
+
+
+def test_context_precision_metric():
+    test_case = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="We offer a 30-day full refund at no extra cost.",
+        expected_output="You are eligible for a 30 day full refund at no extra cost.",
+        retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."]
+    )
+    
+    with (
+        patch.object(
+            context_precision,
+            "_generate_verdicts",
+            return_value=[
+                ContextualPrecisionVerdict(**{"verdict": "yes", "reason": "one"}),
+                ContextualPrecisionVerdict(**{"verdict": "no", "reason": "two"})
+            ]
+        ) as mocked_verdicts,
+        patch.object(
+            context_precision, "_generate_reason", return_value="all good"
+        ) as mocked_reason
+    ):
+        context_precision.measure(test_case)
+        mocked_verdicts.assert_called_with(test_case.input, test_case.expected_output, test_case.retrieval_context)
+        mocked_reason.assert_called_with(test_case.input)
+        assert isinstance(context_precision.score, float)
+        assert isinstance(context_precision.reason, str)
+
+
+def test_context_recall_metric():
+    test_case = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="We offer a 30-day full refund at no extra cost.",
+        expected_output="You are eligible for a 30 day full refund at no extra cost.",
+        retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."]
+    )
+    
+    with (
+        patch.object(
+            context_recall,
+            "_generate_verdicts",
+            return_value=[
+                ContextualRecallVerdict(**{"verdict": "yes", "reason": "one"}),
+                ContextualRecallVerdict(**{"verdict": "no", "reason": "two"})
+            ]
+        ) as mocked_verdicts,
+        patch.object(
+            context_recall, "_generate_reason", return_value="all good"
+        ) as mocked_reason
+    ):
+        context_recall.measure(test_case)
+        mocked_verdicts.assert_called_with(test_case.expected_output, test_case.retrieval_context)
+        mocked_reason.assert_called_with(test_case.expected_output)
+        assert isinstance(context_recall.score, float)
+        assert isinstance(context_recall.reason, str)
+
+
+def test_context_relevancy_metric():
+    test_case = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="We offer a 30-day full refund at no extra cost.",
+        retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."]
+    )
+    
+    with (
+        patch.object(
+            context_relevancy,
+            "_generate_verdicts",
+            return_value=ContextualRelevancyVerdicts(
+                **{
+                    "verdicts":[
+                        {"verdict": "yes", "statement": "one"},
+                        {"verdict": "no", "statement": "second claim", "reason": "two"}
+                    ]
+                }
+            )
+        ) as mocked_verdicts,
+        patch.object(
+            context_relevancy, "_generate_reason", return_value="all good"
+        ) as mocked_reason
+    ):
+        context_relevancy.measure(test_case)
+        mocked_verdicts.assert_called_with(test_case.input, test_case.retrieval_context[0])
+        mocked_reason.assert_called_with(test_case.input)
+        assert isinstance(context_relevancy.score, float)
+        assert isinstance(context_relevancy.reason, str)
+
+
+def test_correctness_metric():
+    test_case = LLMTestCase(
+        input="The dog chased the cat up the tree, who ran up the tree?",
+        actual_output="It depends, some might consider the cat, while others might argue the dog.",
+        expected_output="The cat."
+    )
+    
+    with (
+        patch.object(
+            correctness_metric, "_generate_evaluation_steps", return_value=["first step", "second step"]
+        ),
+        patch.object(
+            correctness_metric,"evaluate", return_value=(1.0, "all good")
+        ) as mocked_evaluate,
+    ):
+        correctness_metric.measure(test_case)
+        mocked_evaluate.assert_called_with(test_case)
+        assert isinstance(correctness_metric.score, float)
+        assert isinstance(correctness_metric.reason, str)
+
+
+def test_faithfulness_metric():
+    test_case = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="We offer a 30-day full refund at no extra cost.",
+        retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."]
+    )
+    
+    with (
+        patch.object(
+            faithfulness, "_generate_truths", return_value=["first truth", "second truth"]
+        ) as mocked_truths,
+        patch.object(
+            faithfulness, "_generate_claims", return_value=["first claim", "second claim"]
+        ) as mocked_claims,
+        patch.object(
+            faithfulness, "_generate_verdicts", return_value=[
+                    FaithfulnessVerdict(**{"verdict": "yes", "reason": "one"}),
+                    FaithfulnessVerdict(**{"verdict": "no", "reason": "two"})
+            ]
+        ),
+        patch.object(
+            faithfulness, "_generate_reason", return_value="all good"
+        )
+    ):
+        faithfulness.measure(test_case)
+        mocked_truths.assert_called_with(test_case.retrieval_context)
+        mocked_claims.assert_called_with(test_case.actual_output)
+        assert isinstance(faithfulness.score, float)
+        assert isinstance(faithfulness.reason, str)
+        
+
+def test_task_completion_metric():
+    test_case = LLMTestCase(
+        input="Plan a 3-day itinerary for Paris with cultural landmarks and local cuisine.",
+        actual_output=(
+            "Day 1: Eiffel Tower, dinner at Le Jules Verne. "
+            "Day 2: Louvre Museum, lunch at Angelina Paris. "
+            "Day 3: Montmartre, evening at a wine bar."
+        ),
+        tools_called=[
+            ToolCall(
+                name="Itinerary Generator",
+                description="Creates travel plans based on destination and duration.",
+                input_parameters={"destination": "Paris", "days": 3},
+                output=[
+                    "Day 1: Eiffel Tower, Le Jules Verne.",
+                    "Day 2: Louvre Museum, Angelina Paris.",
+                    "Day 3: Montmartre, wine bar.",
+                ],
+            ),
+            ToolCall(
+                name="Restaurant Finder",
+                description="Finds top restaurants in a city.",
+                input_parameters={"city": "Paris"},
+                output=["Le Jules Verne", "Angelina Paris", "local wine bars"],
+            ),
+        ],
+    )
+    
+    with (
+        patch.object(
+            task_completion, "_extract_goal_and_outcome", return_value=("goal", "outcome")
+        ) as mocked_goal_and_outcome,
+        patch.object(
+            task_completion, "_generate_verdicts", return_value=(0.85, "just because")
+        )
+    ):
+        task_completion.measure(test_case)
+        mocked_goal_and_outcome.assert_called_with(test_case)
+        assert isinstance(task_completion.score, float)
+        assert isinstance(task_completion.reason, str)
+
+
+def test_tool_correctness_metric():
+    test_case = LLMTestCase(
+        input="What if these shoes don't fit?",
+        actual_output="We offer a 30-day full refund at no extra cost.",
+        tools_called=[ToolCall(name="WebSearch", input_parameters={}), ToolCall(name="ToolQuery", input_parameters={})],
+        expected_tools=[ToolCall(name="WebSearch", input_parameters={})],
+    )
+
+    tool_correctness.measure(test_case)
+    assert isinstance(tool_correctness.score, float)
+    assert isinstance(tool_correctness.reason, str)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,24 +1,12 @@
 from typing import Optional
 from unittest.mock import patch
 
-from deepeval.metrics.answer_relevancy.schema import AnswerRelevancyVerdict
-from deepeval.metrics.contextual_precision.schema import ContextualPrecisionVerdict
-from deepeval.metrics.contextual_recall.schema import ContextualRecallVerdict
-from deepeval.metrics.contextual_relevancy.schema import ContextualRelevancyVerdicts
-from deepeval.metrics.faithfulness.schema import FaithfulnessVerdict
-from deepeval.test_case import LLMTestCase, ToolCall
+from deepeval.test_case import LLMTestCase
 from langchain_core.messages import AIMessage
 from pydantic import BaseModel, Field
 
 from protollm.metrics.deepeval_connector import DeepEvalConnector
-from protollm.metrics.evaluation_metrics import (answer_relevancy,
-                                                 context_precision,
-                                                 context_recall,
-                                                 context_relevancy,
-                                                 correctness_metric,
-                                                 faithfulness,
-                                                 task_completion,
-                                                 tool_correctness)
+from protollm.metrics.evaluation_metrics import correctness_metric
 
 
 class Joke(BaseModel):
@@ -46,120 +34,6 @@ def test_metric_connector_with_schema():
         assert issubclass(type(response), BaseModel)
 
 
-def test_answer_relevancy_metric():
-    test_case = LLMTestCase(
-        input="What if these shoes don't fit?",
-        actual_output="We offer a 30-day full refund at no extra cost.",
-    )
-    
-    with (
-        patch.object(
-            answer_relevancy, "_generate_statements", return_value=["first claim", "second claim"]
-        ) as mocked_statements,
-        patch.object(
-            answer_relevancy,
-            "_generate_verdicts",
-            return_value=[AnswerRelevancyVerdict(**{"verdict": "yes"}), AnswerRelevancyVerdict(**{"verdict": "no"})]
-        ) as mocked_verdicts,
-        patch.object(
-            answer_relevancy, "_generate_reason", return_value="all good"
-        ) as mocked_reason
-    ):
-        answer_relevancy.measure(test_case)
-        mocked_statements.assert_called_with(test_case.actual_output)
-        mocked_verdicts.assert_called_with(test_case.input)
-        mocked_reason.assert_called_with(test_case.input)
-        assert isinstance(answer_relevancy.score, float)
-        assert isinstance(answer_relevancy.reason, str)
-
-
-def test_context_precision_metric():
-    test_case = LLMTestCase(
-        input="What if these shoes don't fit?",
-        actual_output="We offer a 30-day full refund at no extra cost.",
-        expected_output="You are eligible for a 30 day full refund at no extra cost.",
-        retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."]
-    )
-    
-    with (
-        patch.object(
-            context_precision,
-            "_generate_verdicts",
-            return_value=[
-                ContextualPrecisionVerdict(**{"verdict": "yes", "reason": "one"}),
-                ContextualPrecisionVerdict(**{"verdict": "no", "reason": "two"})
-            ]
-        ) as mocked_verdicts,
-        patch.object(
-            context_precision, "_generate_reason", return_value="all good"
-        ) as mocked_reason
-    ):
-        context_precision.measure(test_case)
-        mocked_verdicts.assert_called_with(test_case.input, test_case.expected_output, test_case.retrieval_context)
-        mocked_reason.assert_called_with(test_case.input)
-        assert isinstance(context_precision.score, float)
-        assert isinstance(context_precision.reason, str)
-
-
-def test_context_recall_metric():
-    test_case = LLMTestCase(
-        input="What if these shoes don't fit?",
-        actual_output="We offer a 30-day full refund at no extra cost.",
-        expected_output="You are eligible for a 30 day full refund at no extra cost.",
-        retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."]
-    )
-    
-    with (
-        patch.object(
-            context_recall,
-            "_generate_verdicts",
-            return_value=[
-                ContextualRecallVerdict(**{"verdict": "yes", "reason": "one"}),
-                ContextualRecallVerdict(**{"verdict": "no", "reason": "two"})
-            ]
-        ) as mocked_verdicts,
-        patch.object(
-            context_recall, "_generate_reason", return_value="all good"
-        ) as mocked_reason
-    ):
-        context_recall.measure(test_case)
-        mocked_verdicts.assert_called_with(test_case.expected_output, test_case.retrieval_context)
-        mocked_reason.assert_called_with(test_case.expected_output)
-        assert isinstance(context_recall.score, float)
-        assert isinstance(context_recall.reason, str)
-
-
-def test_context_relevancy_metric():
-    test_case = LLMTestCase(
-        input="What if these shoes don't fit?",
-        actual_output="We offer a 30-day full refund at no extra cost.",
-        retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."]
-    )
-    
-    with (
-        patch.object(
-            context_relevancy,
-            "_generate_verdicts",
-            return_value=ContextualRelevancyVerdicts(
-                **{
-                    "verdicts":[
-                        {"verdict": "yes", "statement": "one"},
-                        {"verdict": "no", "statement": "second claim", "reason": "two"}
-                    ]
-                }
-            )
-        ) as mocked_verdicts,
-        patch.object(
-            context_relevancy, "_generate_reason", return_value="all good"
-        ) as mocked_reason
-    ):
-        context_relevancy.measure(test_case)
-        mocked_verdicts.assert_called_with(test_case.input, test_case.retrieval_context[0])
-        mocked_reason.assert_called_with(test_case.input)
-        assert isinstance(context_relevancy.score, float)
-        assert isinstance(context_relevancy.reason, str)
-
-
 def test_correctness_metric():
     test_case = LLMTestCase(
         input="The dog chased the cat up the tree, who ran up the tree?",
@@ -179,89 +53,3 @@ def test_correctness_metric():
         mocked_evaluate.assert_called_with(test_case)
         assert isinstance(correctness_metric.score, float)
         assert isinstance(correctness_metric.reason, str)
-
-
-def test_faithfulness_metric():
-    test_case = LLMTestCase(
-        input="What if these shoes don't fit?",
-        actual_output="We offer a 30-day full refund at no extra cost.",
-        retrieval_context=["All customers are eligible for a 30 day full refund at no extra cost."]
-    )
-    
-    with (
-        patch.object(
-            faithfulness, "_generate_truths", return_value=["first truth", "second truth"]
-        ) as mocked_truths,
-        patch.object(
-            faithfulness, "_generate_claims", return_value=["first claim", "second claim"]
-        ) as mocked_claims,
-        patch.object(
-            faithfulness, "_generate_verdicts", return_value=[
-                    FaithfulnessVerdict(**{"verdict": "yes", "reason": "one"}),
-                    FaithfulnessVerdict(**{"verdict": "no", "reason": "two"})
-            ]
-        ),
-        patch.object(
-            faithfulness, "_generate_reason", return_value="all good"
-        )
-    ):
-        faithfulness.measure(test_case)
-        mocked_truths.assert_called_with(test_case.retrieval_context)
-        mocked_claims.assert_called_with(test_case.actual_output)
-        assert isinstance(faithfulness.score, float)
-        assert isinstance(faithfulness.reason, str)
-        
-
-def test_task_completion_metric():
-    test_case = LLMTestCase(
-        input="Plan a 3-day itinerary for Paris with cultural landmarks and local cuisine.",
-        actual_output=(
-            "Day 1: Eiffel Tower, dinner at Le Jules Verne. "
-            "Day 2: Louvre Museum, lunch at Angelina Paris. "
-            "Day 3: Montmartre, evening at a wine bar."
-        ),
-        tools_called=[
-            ToolCall(
-                name="Itinerary Generator",
-                description="Creates travel plans based on destination and duration.",
-                input_parameters={"destination": "Paris", "days": 3},
-                output=[
-                    "Day 1: Eiffel Tower, Le Jules Verne.",
-                    "Day 2: Louvre Museum, Angelina Paris.",
-                    "Day 3: Montmartre, wine bar.",
-                ],
-            ),
-            ToolCall(
-                name="Restaurant Finder",
-                description="Finds top restaurants in a city.",
-                input_parameters={"city": "Paris"},
-                output=["Le Jules Verne", "Angelina Paris", "local wine bars"],
-            ),
-        ],
-    )
-    
-    with (
-        patch.object(
-            task_completion, "_extract_goal_and_outcome", return_value=("goal", "outcome")
-        ) as mocked_goal_and_outcome,
-        patch.object(
-            task_completion, "_generate_verdicts", return_value=(0.85, "just because")
-        )
-    ):
-        task_completion.measure(test_case)
-        mocked_goal_and_outcome.assert_called_with(test_case)
-        assert isinstance(task_completion.score, float)
-        assert isinstance(task_completion.reason, str)
-
-
-def test_tool_correctness_metric():
-    test_case = LLMTestCase(
-        input="What if these shoes don't fit?",
-        actual_output="We offer a 30-day full refund at no extra cost.",
-        tools_called=[ToolCall(name="WebSearch", input_parameters={}), ToolCall(name="ToolQuery", input_parameters={})],
-        expected_tools=[ToolCall(name="WebSearch", input_parameters={})],
-    )
-
-    tool_correctness.measure(test_case)
-    assert isinstance(tool_correctness.score, float)
-    assert isinstance(tool_correctness.reason, str)


### PR DESCRIPTION
- Added connector class for working with metrics from [deepeval](https://docs.confident-ai.com/docs/getting-started)
- Added initialisation of basic metrics using LLM and one not using LLM
- Added tests for the connector and for metrics
- Added example of metrics usage