### PR TITLE
Add support for self-hosted models

### DIFF
--- a/examples/connector_creator_usage_example.py
+++ b/examples/connector_creator_usage_example.py
@@ -243,7 +243,8 @@ if __name__ == "__main__":
     # model_url_and_name = os.getenv("DEEPSEEK_R1_URL")
     # model_url_and_name = os.getenv("GPT4_URL")
     # model_url_and_name = os.getenv("OPENAI_URL")
-    model_url_and_name = os.getenv("OLLAMA_URL")
+    # model_url_and_name = os.getenv("OLLAMA_URL")
+    model_url_and_name = os.getenv("SELF_HOSTED_LLM")
     
     # Uncomment the example you want to run
     basic_call_example(model_url_and_name)

--- a/protollm/connectors/README.md
+++ b/protollm/connectors/README.md
@@ -48,7 +48,7 @@ model = create_llm_connector("https://api.vsegpt.ru/v1;openai/gpt-4o-mini", temp
 res = model.invoke("Tell me a joke")
 print(res.content)
 ```
-The rest of the examples you can [here](https://github.com/ITMO-NSS-team/ProtoLLM/tree/main/examples/connector_creator_usage_examples.py)
+You can find the rest of the examples [here](https://github.com/ITMO-NSS-team/ProtoLLM/tree/main/examples/connector_creator_usage_examples.py)
 
 ## New connectors
 

--- a/protollm/connectors/README.md
+++ b/protollm/connectors/README.md
@@ -13,6 +13,23 @@ corresponding system prompt is applied. Lists of models that have problems are k
 It is also important to note that additional certifications are required to use Gigachat models. Instructions on how to
 install them can be found [here](https://developers.sber.ru/docs/ru/gigachat/certificates).
 
+## Supported providers/LLM hosting services:
+1. https://api.vsepgt.ru/v1
+   - VSE_GPT_KEY env variable
+   - example of an argument for a function: `https://api.vsegpt.ru/v1;openai/gpt-4o-mini`
+2. https://api.openai.com/v1
+   - OPENAI_KEY env variable
+   - example of an argument for a function: `https://api.openai.com/v1;gpt-4o-mini`
+3. https://gigachat.devices.sberbank.ru/api/v1
+   - AUTHORIZATION_KEY env variable, which can be obtained from your personal account
+   - example of an argument for a function: `https://gigachat.devices.sberbank.ru/api/v1/chat/completions;GigaChat-Pro`
+4. Ollama (no API key required)
+   - example of an argument for a function: `ollama;http://localhost:11434;llama3.2`
+5. Self-hosted LLM (under FastAPI, no API key required)
+   - example of an argument for a function: `self_hosted;http://99.99.99.99:9999;example_model`
+
+Before use, make sure that your config file has the necessary API key or set it in the environment yourself.
+
 ## Examples of usage
 
 To create a connector it is necessary to pass to the function the URL of the corresponding service combined with the
@@ -20,12 +37,8 @@ model name with a semicolon (;), for example: `https://api.vsegpt.ru/v1;openai/g
 
 It is also possible to pass additional parameters for the model.  Available parameters:
 - `temperature`
-- `top_p`
+- `top_p` (not available for self-hosted models)
 - `max_tokens`
-
-Before use, make sure that your config file has the necessary API key (`VSE_GPT_KEY` by default or `OPENAI_KEY`), or in
-the case of Gigachat models, an authorisation key (`AUTHORIZATION_KEY`), which can be obtained from your personal 
-account.
 
 Example of how to use the function:
 ```codeblock
@@ -35,11 +48,10 @@ model = create_llm_connector("https://api.vsegpt.ru/v1;openai/gpt-4o-mini", temp
 res = model.invoke("Tell me a joke")
 print(res.content)
 ```
-The rest of the examples are located in the `examples/connector_creator_usage_examples.py` module of the repository.
+The rest of the examples you can [here](https://github.com/ITMO-NSS-team/ProtoLLM/tree/main/examples/connector_creator_usage_examples.py)
 
 ## New connectors
 
-For now connectors are available for services supporting the OpenAI API format, as well as for Gigachat family models.
 If you want to add a new connector, you need to implement a class based on the BaseChatModel class with all the
 necessary methods. Instructions for implementation available 
 [here](https://python.langchain.com/docs/how_to/custom_chat_model/).

--- a/protollm/connectors/connector_creator.py
+++ b/protollm/connectors/connector_creator.py
@@ -1,22 +1,23 @@
-import json
 import os
-from typing import Any, Dict, List
-import re
+from typing import Any
 
 from dotenv import load_dotenv
-from langchain_core.messages import AIMessage, SystemMessage, HumanMessage
-from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
-from langchain_core.tools import BaseTool
+from langchain_core.messages import AIMessage
 from langchain_core.runnables import Runnable
 from langchain_gigachat import GigaChat
 from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from protollm.connectors.rest_server import ChatRESTServer
 from protollm.connectors.utils import (get_access_token,
                                        models_without_function_calling,
-                                       models_without_structured_output)
+                                       models_without_structured_output,
+                                       generate_system_prompt_with_schema,
+                                       generate_system_prompt_with_tools,
+                                       parse_function_calls,
+                                       parse_custom_structure,
+                                       handle_system_prompt)
 from protollm.definitions import CONFIG_PATH
 
 
@@ -47,23 +48,23 @@ class CustomChatOpenAI(ChatOpenAI):
     def invoke(self, messages: str | list, *args, **kwargs) -> AIMessage | dict | BaseModel:
         
         if self._requires_custom_handling_for_tools() and self._tools:
-            system_prompt = self._generate_system_prompt_with_tools()
-            messages = self._handle_system_prompt(messages, system_prompt)
+            system_prompt = generate_system_prompt_with_tools(self._tools, self._tool_choice_mode)
+            messages = handle_system_prompt(messages, system_prompt)
         
         if self._requires_custom_handling_for_structured_output() and self._response_format:
-            system_prompt = self._generate_system_prompt_with_schema()
-            messages = self._handle_system_prompt(messages, system_prompt)
+            system_prompt = generate_system_prompt_with_schema(self._response_format)
+            messages = handle_system_prompt(messages, system_prompt)
 
         response = self._super_invoke(messages, *args, **kwargs)
 
         match response:
             case AIMessage() if ("<function=" in response.content):
-                tool_calls = self._parse_function_calls(response.content)
+                tool_calls = parse_function_calls(response.content)
                 if tool_calls:
                     response.tool_calls = tool_calls
                     response.content = ""
             case AIMessage() if self._response_format:
-                response = self._parse_custom_structure(response)
+                response = parse_custom_structure(self._response_format, response)
 
         return response
     
@@ -85,87 +86,6 @@ class CustomChatOpenAI(ChatOpenAI):
         else:
             return super().with_structured_output(*args, **kwargs)
 
-    def _generate_system_prompt_with_tools(self) -> str:
-        """
-        Generates a system prompt with function descriptions and instructions for the model.
-        
-        Returns:
-            System prompt with instructions for calling functions and descriptions of the functions themselves.
-        
-        Raises:
-            ValueError: If tools in an unsupported format have been passed.
-        """
-        tool_descriptions = []
-        match self._tool_choice_mode:
-            case "auto" | None | "any" | "required" | True:
-                tool_choice_mode = str(self._tool_choice_mode)
-            case _:
-                tool_choice_mode = f"<<{self._tool_choice_mode}>>"
-        for tool in self._tools:
-            match tool:
-                case dict():
-                    tool_descriptions.append(
-                        f"Function name: {tool['name']}\n"
-                        f"Description: {tool['description']}\n"
-                        f"Parameters: {json.dumps(tool['parameters'], ensure_ascii=False)}"
-                    )
-                case BaseTool():
-                    tool_descriptions.append(
-                        f"Function name: {tool.name}\n"
-                        f"Description: {tool.description}\n"
-                        f"Parameters: {json.dumps(tool.args, ensure_ascii=False)}"
-                    )
-                case _:
-                    raise ValueError(
-                        "Unsupported tool type. Try using a dictionary or function with the @tool decorator as tools"
-                    )
-        tool_prefix = "You have access to the following functions:\n\n"
-        tool_instructions = (
-            "There are the following 4 function call options:\n"
-            "- str of the form <<tool_name>>: call <<tool_name>> tool.\n"
-            "- 'auto': automatically select a tool (including no tool).\n"
-            "- 'none': don't call a tool.\n"
-            "- 'any' or 'required' or 'True': at least one tool have to be called.\n\n"
-            f"User-selected option - {tool_choice_mode}\n\n"
-            "If you choose to call a function ONLY reply in the following format with no prefix or suffix:\n"
-            '<function=example_function_name>{"example_name": "example_value"}</function>'
-        )
-        return tool_prefix + "\n\n".join(tool_descriptions) + "\n\n" + tool_instructions
-    
-    def _generate_system_prompt_with_schema(self) -> str:
-        """
-        Generates a system prompt with response format descriptions and instructions for the model.
-        
-        Returns:
-            A system prompt with instructions for structured output and descriptions of the response formats themselves.
-            
-        Raises:
-            ValueError: If the structure descriptions for the response were passed in an unsupported format.
-        """
-        schema_descriptions = []
-        match self._response_format:
-            case list():
-                schemas = self._response_format
-            case _:
-                schemas = [self._response_format]
-        for schema in schemas:
-            match schema:
-                case dict():
-                    schema_descriptions.append(str(schema))
-                case _ if issubclass(schema, BaseModel):
-                    schema_descriptions.append(str(schema.model_json_schema()))
-                case _:
-                    raise ValueError(
-                        "Unsupported schema type. Try using a description of the answer structure as a dictionary or"
-                        " Pydantic model."
-                    )
-        schema_prefix = "Generate a JSON object that matches one of the following schemas:\n\n"
-        schema_instructions = (
-            "Your response must contain ONLY valid JSON, parsable by a standard JSON parser. Do not include any"
-            " additional text, explanations, or comments."
-        )
-        return schema_prefix + "\n\n".join(schema_descriptions) + "\n\n" + schema_instructions
-
     def _requires_custom_handling_for_tools(self) -> bool:
         """
         Determines whether additional processing for tool calling is required for the current model.
@@ -177,86 +97,6 @@ class CustomChatOpenAI(ChatOpenAI):
         Determines whether additional processing for structured output is required for the current model.
         """
         return any(model_name in self.model_name.lower() for model_name in models_without_structured_output)
-    
-    def _parse_custom_structure(self, response_from_model) -> dict | BaseModel | None:
-        """
-        Parses the model response into a dictionary or Pydantic class
-        
-        Args:
-            response_from_model: response of a model that does not support structured output by default
-        
-        Raises:
-            ValueError: If a structured response is not obtained
-        """
-        match [self._response_format][0]:
-            case dict():
-                try:
-                    parser = JsonOutputParser()
-                    return parser.invoke(response_from_model)
-                except json.JSONDecodeError as e:
-                    raise ValueError(
-                        "Failed to return structured output. There may have been a problem with loading JSON from the"
-                        f" model.\n{e}"
-                    )
-            case _ if issubclass([self._response_format][0], BaseModel):
-                for schema in [self._response_format]:
-                    try:
-                        parser = PydanticOutputParser(pydantic_object=schema)
-                        return parser.invoke(response_from_model)
-                    except ValidationError:
-                        continue
-                raise ValueError(
-                    "Failed to return structured output. There may have been a problem with validating JSON from the"
-                    " model."
-                )
-        
-    @staticmethod
-    def _parse_function_calls(content: str) -> List[Dict[str, Any]]:
-        """
-        Parses LLM answer (HTML string) to extract function calls.
-
-        Args:
-            content: model response as an HTML string
-
-        Returns:
-            A list of dictionaries in tool_calls format
-            
-        Raises:
-            ValueError: If the arguments for a function call are returned in an incorrect format
-        """
-        tool_calls = []
-        pattern = r"<function=(.*?)>(.*?)</function>"
-        matches = re.findall(pattern, content, re.DOTALL)
-
-        for match in matches:
-            function_name, function_args = match
-            try:
-                arguments = json.loads(function_args)
-            except json.JSONDecodeError as e:
-                raise ValueError(f"Error when decoding function arguments: {e}")
-
-            tool_call = {
-                "id": f"call_{len(tool_calls) + 1}",
-                "type": "tool_call",
-                "name": function_name,
-                "args": arguments
-            }
-            tool_calls.append(tool_call)
-
-        return tool_calls
-    
-    @staticmethod
-    def _handle_system_prompt(msgs, sys_prompt):
-        match msgs:
-            case str():
-                return [SystemMessage(content=sys_prompt), HumanMessage(content=msgs)]
-            case list():
-                if not any(isinstance(msg, SystemMessage) for msg in msgs):
-                    msgs.insert(0, SystemMessage(content=sys_prompt))
-                else:
-                    idx = next((index for index, obj in enumerate(msgs) if isinstance(obj, SystemMessage)), 0)
-                    msgs[idx].content += "\n\n" + sys_prompt
-        return msgs
 
 
 def create_llm_connector(model_url: str, *args: Any, **kwargs: Any) -> CustomChatOpenAI | GigaChat | ChatOpenAI:

--- a/protollm/connectors/rest_server.py
+++ b/protollm/connectors/rest_server.py
@@ -1,83 +1,109 @@
 import json
+import re
 from typing import Any, Dict, List, Optional, Union
+from uuid import uuid4
 
 import requests
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (AIMessage, BaseMessage, HumanMessage,
                                      SystemMessage)
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ValidationError
 
 
 class ChatRESTServer(BaseChatModel):
-    model: Optional[str] = 'llama3'
-    base_url: str = 'http://10.32.2.2:8672'
-    timeout: Optional[int] = None
-    """Timeout for the request stream"""
+    model_name: Optional[str] = 'llama'
+    base_url: str = 'http://localhost'
+    max_tokens: int = 2048
+    temperature: float = 0.1
+    
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._response_format = None
+        self._tool_choice_mode = None
+        self._tools = None
 
     @property
     def _llm_type(self) -> str:
         """Return type of chat model."""
         return "chat-rest-server"
 
+    @property
+    def _identifying_params(self) -> Dict[str, Any]:
+        """Return a dictionary of identifying parameters.
+
+        This information is used by the LangChain callback system, which
+        is used for tracing purposes make it possible to monitor LLMs.
+        """
+        return {
+            "model_name": self.model_name,
+            "url": self.base_url
+        }
+
+    @staticmethod
     def _convert_messages_to_rest_server_messages(
-            self, messages: List[BaseMessage]
+            messages: List[BaseMessage]
     ) -> List[Dict[str, Union[str, List[str]]]]:
         chat_messages: List = []
         for message in messages:
-            role = ""
-        match message:
-            case HumanMessage():
-                role = "user"
-            case AIMessage():
-                role = "assistant"
-            case SystemMessage():
-                role = "system"
-            case _:
-                raise ValueError("Received unsupported message type.")
+            match message:
+                case HumanMessage():
+                    role = "user"
+                case AIMessage():
+                    role = "assistant"
+                case SystemMessage():
+                    role = "system"
+                case _:
+                    raise ValueError("Received unsupported message type.")
 
-
-        content = ""
-        if isinstance(message.content, str):
-            content = message.content
-        else:
-            raise ValueError(
-                "Unsupported message content type. "
-                "Must have type 'text' "
+            if isinstance(message.content, str):
+                content = message.content
+            else:
+                raise ValueError(
+                    "Unsupported message content type. "
+                    "Must have type 'text' "
+                )
+            chat_messages.append(
+                {
+                    "role": role,
+                    "content": content
+                }
             )
-        chat_messages.append(
-            {
-                "role": role,
-                "content": content
-            }
-        )
         return chat_messages
 
-    def create_chat(
+    def _create_chat(
             self,
             messages: List[BaseMessage],
             stop: Optional[List[str]] = None,
             **kwargs: Any,
     ) -> Dict[str, Any]:
+        additional_arguments = kwargs
         payload = {
-            "model": self.model,
-            "messages": self._convert_messages_to_rest_server_messages(
-                messages)
+            "job_id": str(uuid4()),
+            "priority": None,
+            "source": "local",
+            "meta": {
+                "temperature": self.temperature,
+                "tokens_limit": self.max_tokens,
+                "stop_words": stop,
+                "model": None
+            },
+            "messages": self._convert_messages_to_rest_server_messages(messages)
         }
 
-        if self.base_url=='mock':
-            return {'test':'test'}
-
         response = requests.post(
-            url=f'{self.base_url}/v1/chat/completions',
+            url=f'{self.base_url}/chat_completion',
             headers={"Content-Type": "application/json"},
             json=payload,
-            timeout=self.timeout
         )
         response.encoding = "utf-8"
         match response.status_code:
             case 200:
-                pass  # Status code is 200, no action needed
+                pass
             case 404:
                 raise ValueError(
                     "CustomWeb call failed with status code 404. "
@@ -102,19 +128,202 @@ class ChatRESTServer(BaseChatModel):
         response = self._create_chat(messages, stop, **kwargs)
         chat_generation = ChatGeneration(
             message=AIMessage(
-                content=response['choices'][0]['message']['content']),
-            generation_info=response,
+                content=response['content']),
         )
         return ChatResult(generations=[chat_generation])
-
-    @property
-    def _identifying_params(self) -> Dict[str, Any]:
-        """Return a dictionary of identifying parameters.
-
-        This information is used by the LangChain callback system, which
-        is used for tracing purposes make it possible to monitor LLMs.
+    
+    def invoke(self, messages: str | list, *args, **kwargs) -> AIMessage | dict | BaseModel:
+        
+        if self._tools:
+            system_prompt = self._generate_system_prompt_with_tools()
+            messages = self._handle_system_prompt(messages, system_prompt)
+        
+        if self._response_format:
+            system_prompt = self._generate_system_prompt_with_schema()
+            messages = self._handle_system_prompt(messages, system_prompt)
+        
+        response = self._super_invoke(messages, *args, **kwargs)
+        
+        match response:
+            case AIMessage() if ("<function=" in response.content):
+                tool_calls = self._parse_function_calls(response.content)
+                if tool_calls:
+                    response.tool_calls = tool_calls
+                    response.content = ""
+            case AIMessage() if self._response_format:
+                response = self._parse_custom_structure(response)
+        
+        return response
+    
+    def _super_invoke(self, messages, *args, **kwargs):
+        return super().invoke(messages, *args, **kwargs)
+    
+    def bind_tools(self, *args, **kwargs: Any) -> Runnable:
+        self._tools = kwargs.get("tools", [])
+        self._tool_choice_mode = kwargs.get("tool_choice", "auto")
+        return self
+    
+    def with_structured_output(self, *args, **kwargs: Any) -> Runnable:
+        self._response_format = kwargs.get("schema", [])
+        return self
+    
+    def _generate_system_prompt_with_tools(self) -> str:
         """
-        return {
-            "model_name": self.model,
-            "url": self.base_url
-        }
+        Generates a system prompt with function descriptions and instructions for the model.
+
+        Returns:
+            System prompt with instructions for calling functions and descriptions of the functions themselves.
+
+        Raises:
+            ValueError: If tools in an unsupported format have been passed.
+        """
+        tool_descriptions = []
+        match self._tool_choice_mode:
+            case "auto" | None | "any" | "required" | True:
+                tool_choice_mode = str(self._tool_choice_mode)
+            case _:
+                tool_choice_mode = f"<<{self._tool_choice_mode}>>"
+        for tool in self._tools:
+            match tool:
+                case dict():
+                    tool_descriptions.append(
+                        f"Function name: {tool['name']}\n"
+                        f"Description: {tool['description']}\n"
+                        f"Parameters: {json.dumps(tool['parameters'], ensure_ascii=False)}"
+                    )
+                case BaseTool():
+                    tool_descriptions.append(
+                        f"Function name: {tool.name}\n"
+                        f"Description: {tool.description}\n"
+                        f"Parameters: {json.dumps(tool.args, ensure_ascii=False)}"
+                    )
+                case _:
+                    raise ValueError(
+                        "Unsupported tool type. Try using a dictionary or function with the @tool decorator as tools"
+                    )
+        tool_prefix = "You have access to the following functions:\n\n"
+        tool_instructions = (
+            "There are the following 4 function call options:\n"
+            "- str of the form <<tool_name>>: call <<tool_name>> tool.\n"
+            "- 'auto': automatically select a tool (including no tool).\n"
+            "- 'none': don't call a tool.\n"
+            "- 'any' or 'required' or 'True': at least one tool have to be called.\n\n"
+            f"User-selected option - {tool_choice_mode}\n\n"
+            "If you choose to call a function ONLY reply in the following format with no prefix or suffix:\n"
+            '<function=example_function_name>{"example_name": "example_value"}</function>'
+        )
+        return tool_prefix + "\n\n".join(tool_descriptions) + "\n\n" + tool_instructions
+    
+    def _generate_system_prompt_with_schema(self) -> str:
+        """
+        Generates a system prompt with response format descriptions and instructions for the model.
+
+        Returns:
+            A system prompt with instructions for structured output and descriptions of the response formats themselves.
+
+        Raises:
+            ValueError: If the structure descriptions for the response were passed in an unsupported format.
+        """
+        schema_descriptions = []
+        match self._response_format:
+            case list():
+                schemas = self._response_format
+            case _:
+                schemas = [self._response_format]
+        for schema in schemas:
+            match schema:
+                case dict():
+                    schema_descriptions.append(str(schema))
+                case _ if issubclass(schema, BaseModel):
+                    schema_descriptions.append(str(schema.model_json_schema()))
+                case _:
+                    raise ValueError(
+                        "Unsupported schema type. Try using a description of the answer structure as a dictionary or"
+                        " Pydantic model."
+                    )
+        schema_prefix = "Generate a JSON object that matches one of the following schemas:\n\n"
+        schema_instructions = (
+            "Your response must contain ONLY valid JSON, parsable by a standard JSON parser. Do not include any"
+            " additional text, explanations, or comments."
+        )
+        return schema_prefix + "\n\n".join(schema_descriptions) + "\n\n" + schema_instructions
+    
+    @staticmethod
+    def _parse_function_calls(content: str) -> List[Dict[str, Any]]:
+        """
+        Parses LLM answer (HTML string) to extract function calls.
+
+        Args:
+            content: model response as an HTML string
+
+        Returns:
+            A list of dictionaries in tool_calls format
+
+        Raises:
+            ValueError: If the arguments for a function call are returned in an incorrect format
+        """
+        tool_calls = []
+        pattern = r"<function=(.*?)>(.*?)</function>"
+        matches = re.findall(pattern, content, re.DOTALL)
+        
+        for match in matches:
+            function_name, function_args = match
+            try:
+                arguments = json.loads(function_args)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Error when decoding function arguments: {e}")
+            
+            tool_call = {
+                "id": f"call_{len(tool_calls) + 1}",
+                "type": "tool_call",
+                "name": function_name,
+                "args": arguments
+            }
+            tool_calls.append(tool_call)
+        
+        return tool_calls
+
+    def _parse_custom_structure(self, response_from_model) -> dict | BaseModel | None:
+        """
+        Parses the model response into a dictionary or Pydantic class
+
+        Args:
+            response_from_model: response of a model that does not support structured output by default
+
+        Raises:
+            ValueError: If a structured response is not obtained
+        """
+        match [self._response_format][0]:
+            case dict():
+                try:
+                    parser = JsonOutputParser()
+                    return parser.invoke(response_from_model)
+                except json.JSONDecodeError as e:
+                    raise ValueError(
+                        "Failed to return structured output. There may have been a problem with loading JSON from the"
+                        f" model.\n{e}"
+                    )
+            case _ if issubclass([self._response_format][0], BaseModel):
+                for schema in [self._response_format]:
+                    try:
+                        parser = PydanticOutputParser(pydantic_object=schema)
+                        return parser.invoke(response_from_model)
+                    except ValidationError:
+                        continue
+                raise ValueError(
+                    "Failed to return structured output. There may have been a problem with validating JSON from the"
+                    " model."
+                )
+
+    @staticmethod
+    def _handle_system_prompt(msgs, sys_prompt):
+        match msgs:
+            case str():
+                return [SystemMessage(content=sys_prompt), HumanMessage(content=msgs)]
+            case list():
+                if not any(isinstance(msg, SystemMessage) for msg in msgs):
+                    msgs.insert(0, SystemMessage(content=sys_prompt))
+                else:
+                    idx = next((index for index, obj in enumerate(msgs) if isinstance(obj, SystemMessage)), 0)
+                    msgs[idx].content += "\n\n" + sys_prompt
+        return msgs

--- a/protollm/connectors/rest_server.py
+++ b/protollm/connectors/rest_server.py
@@ -1,5 +1,4 @@
 import json
-import re
 from typing import Any, Dict, List, Optional, Union
 from uuid import uuid4
 
@@ -8,11 +7,15 @@ from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (AIMessage, BaseMessage, HumanMessage,
                                      SystemMessage)
-from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.runnables import Runnable
-from langchain_core.tools import BaseTool
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
+
+from protollm.connectors.utils import (generate_system_prompt_with_schema,
+                                       generate_system_prompt_with_tools,
+                                       parse_function_calls,
+                                       parse_custom_structure,
+                                       handle_system_prompt)
 
 
 class ChatRESTServer(BaseChatModel):
@@ -81,7 +84,6 @@ class ChatRESTServer(BaseChatModel):
             stop: Optional[List[str]] = None,
             **kwargs: Any,
     ) -> Dict[str, Any]:
-        additional_arguments = kwargs
         payload = {
             "job_id": str(uuid4()),
             "priority": None,
@@ -92,7 +94,8 @@ class ChatRESTServer(BaseChatModel):
                 "stop_words": stop,
                 "model": None
             },
-            "messages": self._convert_messages_to_rest_server_messages(messages)
+            "messages": self._convert_messages_to_rest_server_messages(messages),
+            **kwargs
         }
 
         response = requests.post(
@@ -134,24 +137,24 @@ class ChatRESTServer(BaseChatModel):
     
     def invoke(self, messages: str | list, *args, **kwargs) -> AIMessage | dict | BaseModel:
         
+        system_prompt = ""
         if self._tools:
-            system_prompt = self._generate_system_prompt_with_tools()
-            messages = self._handle_system_prompt(messages, system_prompt)
-        
+            system_prompt = generate_system_prompt_with_tools(self._tools, self._tool_choice_mode)
         if self._response_format:
-            system_prompt = self._generate_system_prompt_with_schema()
-            messages = self._handle_system_prompt(messages, system_prompt)
+            system_prompt = generate_system_prompt_with_schema(self._response_format)
+        
+        messages = handle_system_prompt(messages, system_prompt)
         
         response = self._super_invoke(messages, *args, **kwargs)
         
         match response:
             case AIMessage() if ("<function=" in response.content):
-                tool_calls = self._parse_function_calls(response.content)
+                tool_calls = parse_function_calls(response.content)
                 if tool_calls:
                     response.tool_calls = tool_calls
                     response.content = ""
             case AIMessage() if self._response_format:
-                response = self._parse_custom_structure(response)
+                response = parse_custom_structure(self._response_format, response)
         
         return response
     
@@ -166,164 +169,3 @@ class ChatRESTServer(BaseChatModel):
     def with_structured_output(self, *args, **kwargs: Any) -> Runnable:
         self._response_format = kwargs.get("schema", [])
         return self
-    
-    def _generate_system_prompt_with_tools(self) -> str:
-        """
-        Generates a system prompt with function descriptions and instructions for the model.
-
-        Returns:
-            System prompt with instructions for calling functions and descriptions of the functions themselves.
-
-        Raises:
-            ValueError: If tools in an unsupported format have been passed.
-        """
-        tool_descriptions = []
-        match self._tool_choice_mode:
-            case "auto" | None | "any" | "required" | True:
-                tool_choice_mode = str(self._tool_choice_mode)
-            case _:
-                tool_choice_mode = f"<<{self._tool_choice_mode}>>"
-        for tool in self._tools:
-            match tool:
-                case dict():
-                    tool_descriptions.append(
-                        f"Function name: {tool['name']}\n"
-                        f"Description: {tool['description']}\n"
-                        f"Parameters: {json.dumps(tool['parameters'], ensure_ascii=False)}"
-                    )
-                case BaseTool():
-                    tool_descriptions.append(
-                        f"Function name: {tool.name}\n"
-                        f"Description: {tool.description}\n"
-                        f"Parameters: {json.dumps(tool.args, ensure_ascii=False)}"
-                    )
-                case _:
-                    raise ValueError(
-                        "Unsupported tool type. Try using a dictionary or function with the @tool decorator as tools"
-                    )
-        tool_prefix = "You have access to the following functions:\n\n"
-        tool_instructions = (
-            "There are the following 4 function call options:\n"
-            "- str of the form <<tool_name>>: call <<tool_name>> tool.\n"
-            "- 'auto': automatically select a tool (including no tool).\n"
-            "- 'none': don't call a tool.\n"
-            "- 'any' or 'required' or 'True': at least one tool have to be called.\n\n"
-            f"User-selected option - {tool_choice_mode}\n\n"
-            "If you choose to call a function ONLY reply in the following format with no prefix or suffix:\n"
-            '<function=example_function_name>{"example_name": "example_value"}</function>'
-        )
-        return tool_prefix + "\n\n".join(tool_descriptions) + "\n\n" + tool_instructions
-    
-    def _generate_system_prompt_with_schema(self) -> str:
-        """
-        Generates a system prompt with response format descriptions and instructions for the model.
-
-        Returns:
-            A system prompt with instructions for structured output and descriptions of the response formats themselves.
-
-        Raises:
-            ValueError: If the structure descriptions for the response were passed in an unsupported format.
-        """
-        schema_descriptions = []
-        match self._response_format:
-            case list():
-                schemas = self._response_format
-            case _:
-                schemas = [self._response_format]
-        for schema in schemas:
-            match schema:
-                case dict():
-                    schema_descriptions.append(str(schema))
-                case _ if issubclass(schema, BaseModel):
-                    schema_descriptions.append(str(schema.model_json_schema()))
-                case _:
-                    raise ValueError(
-                        "Unsupported schema type. Try using a description of the answer structure as a dictionary or"
-                        " Pydantic model."
-                    )
-        schema_prefix = "Generate a JSON object that matches one of the following schemas:\n\n"
-        schema_instructions = (
-            "Your response must contain ONLY valid JSON, parsable by a standard JSON parser. Do not include any"
-            " additional text, explanations, or comments."
-        )
-        return schema_prefix + "\n\n".join(schema_descriptions) + "\n\n" + schema_instructions
-    
-    @staticmethod
-    def _parse_function_calls(content: str) -> List[Dict[str, Any]]:
-        """
-        Parses LLM answer (HTML string) to extract function calls.
-
-        Args:
-            content: model response as an HTML string
-
-        Returns:
-            A list of dictionaries in tool_calls format
-
-        Raises:
-            ValueError: If the arguments for a function call are returned in an incorrect format
-        """
-        tool_calls = []
-        pattern = r"<function=(.*?)>(.*?)</function>"
-        matches = re.findall(pattern, content, re.DOTALL)
-        
-        for match in matches:
-            function_name, function_args = match
-            try:
-                arguments = json.loads(function_args)
-            except json.JSONDecodeError as e:
-                raise ValueError(f"Error when decoding function arguments: {e}")
-            
-            tool_call = {
-                "id": f"call_{len(tool_calls) + 1}",
-                "type": "tool_call",
-                "name": function_name,
-                "args": arguments
-            }
-            tool_calls.append(tool_call)
-        
-        return tool_calls
-
-    def _parse_custom_structure(self, response_from_model) -> dict | BaseModel | None:
-        """
-        Parses the model response into a dictionary or Pydantic class
-
-        Args:
-            response_from_model: response of a model that does not support structured output by default
-
-        Raises:
-            ValueError: If a structured response is not obtained
-        """
-        match [self._response_format][0]:
-            case dict():
-                try:
-                    parser = JsonOutputParser()
-                    return parser.invoke(response_from_model)
-                except json.JSONDecodeError as e:
-                    raise ValueError(
-                        "Failed to return structured output. There may have been a problem with loading JSON from the"
-                        f" model.\n{e}"
-                    )
-            case _ if issubclass([self._response_format][0], BaseModel):
-                for schema in [self._response_format]:
-                    try:
-                        parser = PydanticOutputParser(pydantic_object=schema)
-                        return parser.invoke(response_from_model)
-                    except ValidationError:
-                        continue
-                raise ValueError(
-                    "Failed to return structured output. There may have been a problem with validating JSON from the"
-                    " model."
-                )
-
-    @staticmethod
-    def _handle_system_prompt(msgs, sys_prompt):
-        match msgs:
-            case str():
-                return [SystemMessage(content=sys_prompt), HumanMessage(content=msgs)]
-            case list():
-                if not any(isinstance(msg, SystemMessage) for msg in msgs):
-                    msgs.insert(0, SystemMessage(content=sys_prompt))
-                else:
-                    idx = next((index for index, obj in enumerate(msgs) if isinstance(obj, SystemMessage)), 0)
-                    msgs[idx].content += "\n\n" + sys_prompt
-        return msgs

--- a/protollm/connectors/rest_server.py
+++ b/protollm/connectors/rest_server.py
@@ -145,7 +145,7 @@ class ChatRESTServer(BaseChatModel):
         
         messages = handle_system_prompt(messages, system_prompt)
         
-        response = self._super_invoke(messages, *args, **kwargs)
+        response = super().invoke(messages, *args, **kwargs)
         
         match response:
             case AIMessage() if ("<function=" in response.content):
@@ -157,9 +157,6 @@ class ChatRESTServer(BaseChatModel):
                 response = parse_custom_structure(self._response_format, response)
         
         return response
-    
-    def _super_invoke(self, messages, *args, **kwargs):
-        return super().invoke(messages, *args, **kwargs)
     
     def bind_tools(self, *args, **kwargs: Any) -> Runnable:
         self._tools = kwargs.get("tools", [])

--- a/protollm/connectors/utils.py
+++ b/protollm/connectors/utils.py
@@ -1,7 +1,13 @@
 import json
 import os
+import re
+from typing import List, Dict, Any
 import uuid
 
+from langchain_core.messages import SystemMessage, HumanMessage
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ValidationError
 import requests
 
 
@@ -36,3 +42,175 @@ models_without_function_calling = ["r1", "deepseek-chat-alt", "test_model"]
 
 # List of models that do NOT support structured outputs out-of-the-box yet
 models_without_structured_output = ["deepseek-chat", "deepseek-chat-alt", "llama-3.3-70b-instruct", "test_model"]
+
+
+def generate_system_prompt_with_tools(tools: List[Dict | BaseTool], tool_choice_mode: str) -> str:
+    """
+    Generates a system prompt with function descriptions and instructions for the model.
+    
+    Args:
+        tools: tool list for model
+        tool_choice_mode: an indication to the model whether she has to choose a particular tool
+
+    Returns:
+        System prompt with instructions for calling functions and descriptions of the functions themselves.
+
+    Raises:
+        ValueError: If tools in an unsupported format have been passed.
+    """
+    tool_descriptions = []
+    match tool_choice_mode:
+        case "auto" | None | "any" | "required" | True:
+            tool_choice_mode = str(tool_choice_mode)
+        case _:
+            tool_choice_mode = f"<<{tool_choice_mode}>>"
+    for tool in tools:
+        match tool:
+            case dict():
+                tool_descriptions.append(
+                    f"Function name: {tool['name']}\n"
+                    f"Description: {tool['description']}\n"
+                    f"Parameters: {json.dumps(tool['parameters'], ensure_ascii=False)}"
+                )
+            case BaseTool():
+                tool_descriptions.append(
+                    f"Function name: {tool.name}\n"
+                    f"Description: {tool.description}\n"
+                    f"Parameters: {json.dumps(tool.args, ensure_ascii=False)}"
+                )
+            case _:
+                raise ValueError(
+                    "Unsupported tool type. Try using a dictionary or function with the @tool decorator as tools"
+                )
+    tool_prefix = "You have access to the following functions:\n\n"
+    tool_instructions = (
+        "There are the following 4 function call options:\n"
+        "- str of the form <<tool_name>>: call <<tool_name>> tool.\n"
+        "- 'auto': automatically select a tool (including no tool).\n"
+        "- 'none': don't call a tool.\n"
+        "- 'any' or 'required' or 'True': at least one tool have to be called.\n\n"
+        f"User-selected option - {tool_choice_mode}\n\n"
+        "If you choose to call a function ONLY reply in the following format with no prefix or suffix:\n"
+        '<function=example_function_name>{"example_name": "example_value"}</function>'
+    )
+    return tool_prefix + "\n\n".join(tool_descriptions) + "\n\n" + tool_instructions
+
+
+def generate_system_prompt_with_schema(response_format) -> str:
+    """
+    Generates a system prompt with response format descriptions and instructions for the model.
+    
+    Args:
+        response_format: response format as a dictionary or pydantic model
+
+    Returns:
+        A system prompt with instructions for structured output and descriptions of the response formats themselves.
+
+    Raises:
+        ValueError: If the structure descriptions for the response were passed in an unsupported format.
+    """
+    schema_descriptions = []
+    match response_format:
+        case list():
+            schemas = response_format
+        case _:
+            schemas = [response_format]
+    for schema in schemas:
+        match schema:
+            case dict():
+                schema_descriptions.append(str(schema))
+            case _ if issubclass(schema, BaseModel):
+                schema_descriptions.append(str(schema.model_json_schema()))
+            case _:
+                raise ValueError(
+                    "Unsupported schema type. Try using a description of the answer structure as a dictionary or"
+                    " Pydantic model."
+                )
+    schema_prefix = "Generate a JSON object that matches one of the following schemas:\n\n"
+    schema_instructions = (
+        "Your response must contain ONLY valid JSON, parsable by a standard JSON parser. Do not include any"
+        " additional text, explanations, or comments."
+    )
+    return schema_prefix + "\n\n".join(schema_descriptions) + "\n\n" + schema_instructions
+
+
+def parse_custom_structure(response_format, response_from_model) -> dict | BaseModel | None:
+    """
+    Parses the model response into a dictionary or Pydantic class
+
+    Args:
+        response_format: response format as a dictionary or Pydantic model
+        response_from_model: response of a model that does not support structured output by default
+
+    Raises:
+        ValueError: If a structured response is not obtained
+    """
+    match [response_format][0]:
+        case dict():
+            try:
+                parser = JsonOutputParser()
+                return parser.invoke(response_from_model)
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    "Failed to return structured output. There may have been a problem with loading JSON from the"
+                    f" model.\n{e}"
+                )
+        case _ if issubclass([response_format][0], BaseModel):
+            for schema in [response_format]:
+                try:
+                    parser = PydanticOutputParser(pydantic_object=schema)
+                    return parser.invoke(response_from_model)
+                except ValidationError:
+                    continue
+            raise ValueError(
+                "Failed to return structured output. There may have been a problem with validating JSON from the"
+                " model."
+            )
+
+
+def parse_function_calls(content: str) -> List[Dict[str, Any]]:
+    """
+    Parses LLM answer (HTML string) to extract function calls.
+
+    Args:
+        content: model response as an HTML string
+
+    Returns:
+        A list of dictionaries in tool_calls format
+
+    Raises:
+        ValueError: If the arguments for a function call are returned in an incorrect format
+    """
+    tool_calls = []
+    pattern = r"<function=(.*?)>(.*?)</function>"
+    matches = re.findall(pattern, content, re.DOTALL)
+    
+    for match in matches:
+        function_name, function_args = match
+        try:
+            arguments = json.loads(function_args)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Error when decoding function arguments: {e}")
+        
+        tool_call = {
+            "id": f"call_{len(tool_calls) + 1}",
+            "type": "tool_call",
+            "name": function_name,
+            "args": arguments
+        }
+        tool_calls.append(tool_call)
+    
+    return tool_calls
+    
+
+def handle_system_prompt(msgs, sys_prompt):
+    match msgs:
+        case str():
+            return [SystemMessage(content=sys_prompt), HumanMessage(content=msgs)]
+        case list():
+            if not any(isinstance(msg, SystemMessage) for msg in msgs):
+                msgs.insert(0, SystemMessage(content=sys_prompt))
+            else:
+                idx = next((index for index, obj in enumerate(msgs) if isinstance(obj, SystemMessage)), 0)
+                msgs[idx].content += "\n\n" + sys_prompt
+    return msgs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ProtoLLM"
-version = "0.1.2"
+version = "0.1.3"
 description = "A library with which to prototype LLM-based applications quickly and easily."
 requires-python = ">=3.10,<4.0"
 authors = [

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -75,7 +75,7 @@ class ExampleModel(BaseModel):
 def test_self_hosted_invoke():
     conn = ChatRESTServer()
     mock_response = AIMessage(content="Hello, world!")
-    with patch.object(ChatRESTServer, '_super_invoke', return_value=mock_response):
+    with patch.object(ChatRESTServer, 'invoke', return_value=mock_response):
         result = conn.invoke("Hello")
         assert result.content == "Hello, world!"
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -72,11 +72,12 @@ class ExampleModel(BaseModel):
     age: int = Field(description="Person age")
 
 
-def test_connector():
+def test_self_hosted_invoke():
     conn = ChatRESTServer()
-    conn.base_url = 'mock'
-    chat = conn.create_chat(messages=[HumanMessage('M1'), HumanMessage('M2'), HumanMessage('M3')])
-    assert chat is not None
+    mock_response = AIMessage(content="Hello, world!")
+    with patch.object(ChatRESTServer, '_super_invoke', return_value=mock_response):
+        result = conn.invoke("Hello")
+        assert result.content == "Hello, world!"
 
 
 # Basic invoke
@@ -336,6 +337,12 @@ def test_ollama_connector():
     model_url = "ollama;http://localhost:11434;llama3.2"
     connector = create_llm_connector(model_url)
     assert isinstance(connector, ChatOllama)
+    
+
+def test_self_hosted_connector():
+    model_url = "self_hosted;http://99.99.99.99:9999;example_model"
+    connector = create_llm_connector(model_url)
+    assert isinstance(connector, ChatRESTServer)
 
 
 def test_test_model_connector():


### PR DESCRIPTION
- Добавлен коннектор для развернутых на сервере моделей
Формат создания такой же, как у остальных. В метод `create_llm_connector` нужно пробросить строчку вида: `self_hosted;base_url;model_name`. Формально, выбор модели сейчас не доступен сервере, поэтому там можно указывать что угодно
- Доступны tools и структурированный вывод в том же объеме, что и у остальных: функции с декораторами или pydantic-классы для tools; словари или pydantic-классы для структурированного вывода

Замечания и предложения приветствуются