### PR TITLE
Added connector creator for openrouter models

### DIFF
--- a/protollm/connectors/connector_creator.py
+++ b/protollm/connectors/connector_creator.py
@@ -18,7 +18,7 @@ from protollm.connectors.utils import (get_access_token,
                                        parse_function_calls,
                                        parse_custom_structure,
                                        handle_system_prompt)
-from protollm.definitions import CONFIG_PATH
+from protollm.definitions import CONFIG_PATH, LLM_SERVICES
 
 
 load_dotenv(CONFIG_PATH)
@@ -115,9 +115,9 @@ def create_llm_connector(model_url: str, *args: Any, **kwargs: Any) -> CustomCha
         The ChatModel object from 'langchain' that can be used to make requests to the LLM service,
         use tools, get structured output.
     """
-    if "vsegpt" in model_url:
+    if any(service in model_url for service in LLM_SERVICES):
         base_url, model_name = model_url.split(";")
-        api_key = os.getenv("VSE_GPT_KEY")
+        api_key = os.getenv("LLM_SERVICE_KEY")
         return CustomChatOpenAI(model_name=model_name, base_url=base_url, api_key=api_key, *args, **kwargs)
     elif "gigachat" in model_url:
         model_name = model_url.split(";")[1]

--- a/protollm/definitions.py
+++ b/protollm/definitions.py
@@ -3,3 +3,5 @@ import os
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 CONFIG_PATH = os.path.join(ROOT_DIR, 'config.env')
+
+LLM_SERVICES = ["openrouter.ai", "vsegpt"]

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -313,7 +313,15 @@ def test_structured_output_dict_out_of_the_box(custom_chat_openai_with_fc_and_so
 def test_vsegpt_connector(monkeypatch):
     model_url = "https://api.vsegpt.ru/v1;meta-llama/llama-3.1-70b-instruct"
     test_api_key = "test_vsegpt_key"
-    monkeypatch.setenv("VSE_GPT_KEY", test_api_key)
+    monkeypatch.setenv("LLM_SERVICE_KEY", test_api_key)
+    connector = create_llm_connector(model_url)
+    assert isinstance(connector, CustomChatOpenAI)
+
+
+def test_openrouter_connector(monkeypatch):
+    model_url = "https://api.openrouter.ai/v1;meta-llama/llama-3.1-70b-instruct"
+    test_api_key = "test_openrouter_key"
+    monkeypatch.setenv("LLM_SERVICE_KEY", test_api_key)
     connector = create_llm_connector(model_url)
     assert isinstance(connector, CustomChatOpenAI)
 


### PR DESCRIPTION
The connector creator for vsegpt service was extended to work not only with vsegpt but also with other LLM services such as openrouter.ai