### PR TITLE
chore: bump click version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "celery>=5.4.0,<6.0.0",
     "chardet==5.2.0",
     "chromadb>=0.5.0,<0.6.0",
-    "click==8.1.7",
+    "click>=8.2.0",
     "deepeval==2.3.3; python_version >= '3.10' and python_version < '3.14'",
     "fastapi>=0.111.0,<0.112.0",
     "flower>=2.0.1,<3.0.0",


### PR DESCRIPTION
## Why

- Click version 8.1.7 was released on August 17, 2023, while version 8.2.0 became available on May 15, 2025.  
- Several modern packages now depend on Click 8.2.0 or newer, creating incompatibilities with ProtoLLM’s current requirement of Click 8.1.7. 

For example `marker-pdf` package:
```
Because marker-pdf (1.10.1) depends on click (>=8.2.0,<9.0.0)
 and protollm (0.1.5) depends on click (8.1.7), marker-pdf (1.10.1) is incompatible with protollm (0.1.5).
So, because osa-tool depends on both ProtoLLM (0.1.5) and marker-pdf (1.10.1), version solving failed.
```

If this change is acceptable, it would be great if you could publish a new version of ProtoLLM to PyPI. 